### PR TITLE
Provide the user the option to use GPG to sign packages in sandbox

### DIFF
--- a/scripts/run-sandbox
+++ b/scripts/run-sandbox
@@ -88,6 +88,13 @@ else
 		BINPKG_SITES=	${REMOTE_PACKAGE_URL}/${REMOTE_PACKAGE_DIR}/
 	EOF
 fi
+if [ -n ${PKGSRC_GPG_SIGN_AS} ]; then
+	cat >>${chrootdir}${PKGSRC_SYSCONFDIR}/pkg_install.conf <<-EOF
+		GPG=${CMD_GPG}
+		GPG_SIGN_AS=${PKGSRC_GPG_SIGN_AS}
+	EOF
+fi
+
 cat >${chrootdir}${ROOT_HOMEDIR}/.curlrc <<-EOF
 	--capath ${TOOLS_BASEDIR}/etc/openssl/certs
 EOF

--- a/scripts/run-sandbox
+++ b/scripts/run-sandbox
@@ -89,6 +89,12 @@ else
 	EOF
 fi
 if [ -n ${PKGSRC_GPG_SIGN_AS} ]; then
+	ed ${chrootdir}${PKGSRC_SYSCONFDIR}/pkg_install.conf >/dev/null 2>&1 <<-EOF
+		g/^GPG=/d
+		g/^GPG_SIGN_AS=/d
+		w
+		q
+	EOF
 	cat >>${chrootdir}${PKGSRC_SYSCONFDIR}/pkg_install.conf <<-EOF
 		GPG=${CMD_GPG}
 		GPG_SIGN_AS=${PKGSRC_GPG_SIGN_AS}


### PR DESCRIPTION
This should fix the issue #6 and create entries in the `pkg_install.conf` file if needed and if the user configure the `PKGSRC_GPG_SIGN_AS` variable.