### PR TITLE
Fix issue with -lumem for devel/SOPE and devel/gnustep-base

### DIFF
--- a/conf/2016Q4-x86_64/mk.conf
+++ b/conf/2016Q4-x86_64/mk.conf
@@ -321,7 +321,9 @@ PKG_REGISTER_SHELLS=	yes
  && empty(PKGPATH:M*/mongo-tools) \
  && empty(PKGPATH:Msecurity/aide) \
  && empty(PKGPATH:M*/consul) \
- && empty(PKGPATH:Mwip/ghc)
+ && empty(PKGPATH:Mwip/ghc) \
+ && empty(PKGPATH:Mdevel/gnustep-base) \
+ && empty(PKGPATH:Mdevel/SOPE)
 .  if !empty(PKGBUILD:M2013Q1-*) \
    || !empty(PKGBUILD:M201[012]*)
 LIBS+=			-lumem


### PR DESCRIPTION
To build `devel/gnustep-base` and `devel/SOPE` on SmartOS `2016Q4-x86_64` this change is required. I've also tested in on SmartOS `2016Q3-x86_64` but I'm not sure how you merge changes to other `mk.conf` environments in an simple way.