### PR TITLE
Allows published keys to be recv'd and signing to work out of the box

### DIFF
--- a/scripts/run-sandbox
+++ b/scripts/run-sandbox
@@ -91,7 +91,7 @@ if [ -n "${CMD_GPG}" -a -n "${PKGBUILD_GPG_SIGN_AS}" ]; then
 		    ${PKGBUILD_SYSCONFDIR}/gnupg/pkgsrc.gpg --list-keys ${PKGBUILD_GPG_SIGN_AS} >/dev/null 2>&1
 		if [ \$? -ne 0 ]; then
 			${CMD_GPG} --no-default-keyring --primary-keyring \
-			    ${PKGBUILD_SYSCONFDIR}/gnupg/pkgsrc.gpg --recv ${PKGBUILD_GPG_SIGN_AS} >/dev/null 2>&1
+			    ${PKGBUILD_SYSCONFDIR}/gnupg/pkgsrc.gpg --recv-keys ${PKGBUILD_GPG_SIGN_AS} >/dev/null 2>&1
 		fi
 	"
 fi


### PR DESCRIPTION
    Making this change allows me to follow the guide setting up signing but
    skipping the manual step where the key has to be imported in the chroot
    sandbox eachtime.

    With this change as long as PKGBUILD_GPG_SIGN_AS is set correctly before
    run-sandbox, and my key is published to a keyserver, it will
    automatically be setup correctly in the sandbox environment.