### PR TITLE
Add devel/SOPE4 to the libumem exclude list

### DIFF
--- a/include/libumem.mk
+++ b/include/libumem.mk
@@ -2,6 +2,7 @@
 # Add -lumem by default, except for packages where it causes issues.
 #
 .if empty(PKGPATH:Mdevel/SOPE) \
+ && empty(PKGPATH:Mdevel/SOPE4) \
  && empty(PKGPATH:Mdevel/gnustep-base) \
  && empty(PKGPATH:Mdevel/ncurses) \
  && empty(PKGPATH:Mdevel/valgrind) \


### PR DESCRIPTION
The new package devel/SOPE4 (version 4.0.8) has been added to pkgsrc, for that reason it's required to excluded from -lumem.

https://mail-index.netbsd.org/pkgsrc-changes/2019/09/11/msg197328.html