### PR TITLE
Add wip/kea-git to trunk builds

### DIFF
--- a/pkglist/trunk
+++ b/pkglist/trunk
@@ -88,6 +88,7 @@ wip/erlang-basho
 wip/fswatch
 wip/gecode
 wip/gitea
+wip/kea-git
 wip/leveldb
 wip/libcouchbase
 wip/libeio


### PR DESCRIPTION
@niclasr recently got kea building (with some unit test failures) via pkgsrc also on illumos.

It would be nice to have these available in trunk. More info https://gitlab.isc.org/isc-projects/kea/issues/631#note_103035